### PR TITLE
SNMP community: If undefined don't set it

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,4 +28,11 @@ ipmi_network: {}
 #
 
 # IPMI SNMPv2 community
-ipmi_snmp_community: ''
+ipmi_snmp_community: False
+
+# An example would be:
+#
+# .. code-block:: YAML
+#
+#   ipmi_snmp_community: 'public'
+#


### PR DESCRIPTION
setting the snmp community to false will prevent that this role will set a undefined value.